### PR TITLE
Update Flatpak SDKs

### DIFF
--- a/flatpak/org.flathub.electron-sample-app.yml
+++ b/flatpak/org.flathub.electron-sample-app.yml
@@ -5,7 +5,7 @@ sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
 base-version: '22.08'
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.node14
+  - org.freedesktop.Sdk.Extension.node18
 command: run.sh
 separate-locales: false
 finish-args:
@@ -14,7 +14,7 @@ finish-args:
   - --socket=pulseaudio
   - --share=network
 build-options:
-  append-path: /usr/lib/sdk/node14/bin
+  append-path: /usr/lib/sdk/node18/bin
   env:
     NPM_CONFIG_LOGLEVEL: info
 modules:

--- a/flatpak/org.flathub.electron-sample-app.yml
+++ b/flatpak/org.flathub.electron-sample-app.yml
@@ -1,9 +1,9 @@
 app-id: org.flathub.electron-sample-app
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '21.08'
+base-version: '22.08'
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node14
 command: run.sh


### PR DESCRIPTION
Updates the org.freedesktop.Platform runtime and org.electronjs.Electron2.BaseApp base SDKs to version 22.08, and the Node SDK extensions to node18.

This change brings the versions up to what they are currently listed as in the [tutorial](https://docs.flatpak.org/en/latest/electron.html).