### PR TITLE
Update flatpak SDKs channels to 23.08

### DIFF
--- a/flatpak/org.flathub.electron-sample-app.yml
+++ b/flatpak/org.flathub.electron-sample-app.yml
@@ -1,9 +1,9 @@
 app-id: org.flathub.electron-sample-app
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '22.08'
+base-version: '23.08'
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node18
 command: run.sh


### PR DESCRIPTION
Update Channels to version 23.08 in agreement with the [tutorial](https://docs.flatpak.org/en/latest/electron.html)