### PR TITLE
Update Freedesktop and Node.

### DIFF
--- a/flatpak/org.flathub.electron-sample-app.yml
+++ b/flatpak/org.flathub.electron-sample-app.yml
@@ -1,11 +1,11 @@
 app-id: org.flathub.electron-sample-app
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '23.08'
+base-version: '25.08'
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.node18
+  - org.freedesktop.Sdk.Extension.node24
 command: run.sh
 separate-locales: false
 finish-args:
@@ -14,7 +14,7 @@ finish-args:
   - --socket=pulseaudio
   - --share=network
 build-options:
-  append-path: /usr/lib/sdk/node18/bin
+  append-path: /usr/lib/sdk/node24/bin
   env:
     NPM_CONFIG_LOGLEVEL: info
 modules:


### PR DESCRIPTION
Updates:

Freedesktop runtime 23.08 to Freedesktop runtime 24.08 Electron base from 23.08 to 25.08
Node 18 LTS to Node 24 LTS

Freedesktop 23 and Node 18 has reached EOL